### PR TITLE
モーダルスライドの実験中のコードを本番に移動

### DIFF
--- a/app/javascript/entrypoints/js/randoku_slide.js
+++ b/app/javascript/entrypoints/js/randoku_slide.js
@@ -1,6 +1,5 @@
 import Swiper from 'swiper/bundle';
 import 'swiper/swiper-bundle.css';
-// import '../styles/slide.css';
 
 document.addEventListener('DOMContentLoaded', function() {
 

--- a/app/javascript/entrypoints/js/randoku_slide.js
+++ b/app/javascript/entrypoints/js/randoku_slide.js
@@ -1,6 +1,6 @@
 import Swiper from 'swiper/bundle';
 import 'swiper/swiper-bundle.css';
-import '../styles/slide.css';
+// import '../styles/slide.css';
 
 document.addEventListener('DOMContentLoaded', function() {
 

--- a/app/javascript/entrypoints/styles/slide.css
+++ b/app/javascript/entrypoints/styles/slide.css
@@ -77,6 +77,13 @@
   justify-content: center;
   height: 100%;
 }
+.swiper-button-prev,
+.swiper-button-next,
+.sw-close-button {
+  border: none;
+  outline: none;
+  background: transparent;
+}
 .sw-close-button {
   position: absolute;
   cursor: pointer;

--- a/app/view_models/view_model/books_show.rb
+++ b/app/view_models/view_model/books_show.rb
@@ -36,14 +36,22 @@ module ViewModel
       @randoku_imgs_all_count = book.randoku_imgs.all.size
       @randoku_imgs_all =
         book.randoku_imgs.all.order(updated_at: :desc).to_a.map { |img|
-          { id: img.id,
-            updated_at: I18n.l(img.updated_at, format: :short),
-            name: img.name,
-            path: img.path,
-            reading_state: img.reading_state,
-            bookmark_flag: img.bookmark_flag }
+          ViewModel::RandokuImg.new(img: img, book: book)
         }
+    end
+  end
 
+
+  class RandokuImg
+    attr_reader :id, :name, :updated_at, :path, :thumbnail_path, :bookmark_flag
+
+    def initialize(img:, book:)
+      @id = img.id
+      @name = img.name
+      @updated_at = I18n.l(img.updated_at, format: :short)
+      @path = "/#{book.id}/#{img.name}"
+      @thumbnail_path = "/#{book.id}/thumb/sm_#{img.name}"
+      @bookmark_flag = img.bookmark_flag
     end
   end
 end

--- a/app/views/books/_modal_randoku_slide.html.erb
+++ b/app/views/books/_modal_randoku_slide.html.erb
@@ -28,10 +28,10 @@
         </div>
 
         <div class="swiper-pagination"></div>
-        <div id="sw-button-prev" class="swiper-button-prev"></div>
-        <div id="sw-button-next" class="swiper-button-next"></div>
+        <button id="sw-button-prev" class="swiper-button-prev"></button>
+        <button id="sw-button-next" class="swiper-button-next"></button>
 
-        <span id="sw-close-btn" class="sw-close-button">&times;</span>
+        <button id="sw-close-btn" class="sw-close-button">&times;</button>
       </div>
     </div>
   </div>

--- a/app/views/books/_modal_randoku_slide.html.erb
+++ b/app/views/books/_modal_randoku_slide.html.erb
@@ -9,7 +9,7 @@
           <!-- スライド要素を包む要素 -->
           <div class="swiper-wrapper">
             <!-- 各スライド -->
-            <% book.randoku_imgs_all.each do |slide_img| %>
+            <% randoku_imgs_all.each do |slide_img| %>
               <div class="swiper-slide">
                 <div id="sw_img_name" class="sw_img_name">
                   <p><%= slide_img.name %></p>

--- a/app/views/books/_modal_randoku_slide.html.erb
+++ b/app/views/books/_modal_randoku_slide.html.erb
@@ -1,0 +1,37 @@
+<!-- モーダル -->
+<div class="sw-modal">
+  <div class="sw-reveal-outer">
+    <div class="sw-reveal-wrapper">
+      <div class="sw-reveal-inner">
+
+        <!-- Sliderを包むコンテナ要素 -->
+        <div class="swiper">
+          <!-- スライド要素を包む要素 -->
+          <div class="swiper-wrapper">
+            <!-- 各スライド -->
+            <% book.randoku_imgs_all.each do |slide_img| %>
+              <div class="swiper-slide">
+                <div id="sw_img_name" class="sw_img_name">
+                  <p><%= slide_img.name %></p>
+                </div>
+                <div id="sw_bookmark_flag" class="sw_bookmark">
+                </div>
+                <div id="swiper_img" class="sw_img">
+                  <img src="<%= "#{slide_img.path}" %>?#{Time.now.to_i}" alt=" " />
+                </div>
+                <div id="sw_updated_at" class="sw_updated">
+                  <p><%= slide_img.updated_at %></p>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="swiper-pagination"></div>
+        <div id="sw-button-prev" class="swiper-button-prev"></div>
+        <div id="sw-button-next" class="swiper-button-next"></div>
+
+        <span id="sw-close-btn" class="sw-close-button">&times;</span>
+      </div>
+    </div>
+  </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,6 +1,3 @@
-<!-- 乱読画像を表示するためのモーダル -->
-<%= render partial: 'modal_randoku_imgs', locals: { book: book } %>
-
 <h1>登録した本の情報</h1>
 <p>
 <%= book.title %>
@@ -36,7 +33,10 @@
 <% if book.randoku_img_file_names.empty? %>
   "画像がありません"
 <% else %>
-  <% book.randoku_img_file_names.each do |file_name| %>
-    <img src="<%= "/#{book.id}/thumb/#{file_name}" %>?#{Time.now.to_i}"/>
+  <% book.randoku_imgs_all.each_with_index do |img, i| %>
+    <img src="<%= "#{img.thumbnail_path}" %>?#{Time.now.to_i}" alt=" " id="sw_modal_trigger" data-slide-index="<%= i %>" />
   <% end %>
 <% end %>
+
+<!-- 乱読画像を表示するためのモーダル -->
+<%= render partial: 'modal_randoku_slide', locals: { book: book } %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -39,4 +39,4 @@
 <% end %>
 
 <!-- 乱読画像を表示するためのモーダル -->
-<%= render partial: 'modal_randoku_slide', locals: { book: book } %>
+<%= render partial: 'modal_randoku_slide', locals: { randoku_imgs_all: book.randoku_imgs_all } %>


### PR DESCRIPTION
## 概要
- 一冊の本に紐づく乱読画像をクリックするとモーダルが開きスライドが始まります。
- 実験コードを本番のコードに移動させた上で調整した
 
## 依存PR
下記のコードを今回のプルリクに反映させました。
- 実験コードの修正プルリク
  - https://github.com/sandonemaki/my_read_memo/pull/39
- 実験コードに関する最初のプルリク
  - https://github.com/sandonemaki/my_read_memo/pull/38

## 対応したこと・やったこと
- ✅ ユーザーに関係ある機能を実装・変更・改善・修正
- 実験コードを本番に反映

## 挙動確認する手順
- ✅ 手元で挙動確認しなくて良い
- [挙動確認動画](https://user-images.githubusercontent.com/48534295/224079579-99eda924-3041-47a9-bdf0-b6c59974900e.webm)
