### PR TITLE
トップページのランキングボタンをclickを保守性を考えfetchからリダイレクトにした

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -230,12 +230,21 @@ class BooksController < ApplicationController
     all_seidoku_state_books = Book.where(reading_state: '1') # 1 == 精読
     all_books_count = Book.all.count
 
+    randoku_index_common_view_models =
+      ViewModel::BooksRandokuIndexCommon.new(
+        all_randoku_state_books: all_randoku_state_books,
+        all_seidoku_state_books: all_seidoku_state_books,
+        all_books_count: all_books_count,
+      )
+
     seidoku_index_common_view_models =
       ViewModel::BooksSeidokuIndexCommon.new(
         all_randoku_state_books: all_randoku_state_books,
         all_seidoku_state_books: all_seidoku_state_books,
         all_books_count: all_books_count,
       )
+    randoku_index_rank_view_models =
+      ViewModel::BooksRandokuIndexRankMostImgs.new(all_randoku_state_books: all_randoku_state_books)
     seidoku_index_rank_view_models =
       ViewModel::BooksSeidokuIndexRankCreatedBooks.new(all_seidoku_state_books: all_seidoku_state_books)
     render(

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -215,8 +215,10 @@ class BooksController < ApplicationController
     seidoku_index_rank_view_models =
       ViewModel::BooksSeidokuIndexRankMostSeidokuMemos.new(all_seidoku_state_books: all_seidoku_state_books)
     render(
-      'seidoku_index',
+      'index_seidoku_tabs',
       locals: {
+        randoku_books: randoku_index_common_view_models,
+        randoku_rank: randoku_index_rank_view_models,
         seidoku_books: seidoku_index_common_view_models,
         seidoku_rank: seidoku_index_rank_view_models,
       },
@@ -248,7 +250,7 @@ class BooksController < ApplicationController
     seidoku_index_rank_view_models =
       ViewModel::BooksSeidokuIndexRankCreatedBooks.new(all_seidoku_state_books: all_seidoku_state_books)
     render(
-      'index_tabs',
+      'index_seidoku_tabs',
       locals: {
         randoku_books: randoku_index_common_view_models,
         randoku_rank: randoku_index_rank_view_models,
@@ -282,7 +284,7 @@ class BooksController < ApplicationController
     seidoku_index_rank_view_models =
       ViewModel::BooksSeidokuIndexRankMostRandokuImgs.new(all_seidoku_state_books: all_seidoku_state_books)
     render(
-      'index_tabs',
+      'index_seidoku_tabs',
       locals: {
         randoku_books: randoku_index_common_view_models,
         randoku_rank: randoku_index_rank_view_models,

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -103,25 +103,26 @@ class BooksController < ApplicationController
   end
 
   # ランキング：randoku_indexの乱読画像の多い順
-  def randoku_index
-    all_randoku_state_books = Book.where.not(reading_state: '1') # 0 == 乱読, 2 == 通読
-    all_seidoku_state_books = Book.where(reading_state: '1') # 1 == 精読
-    all_books_count = Book.all.count
+  # fetchでランキングを取得する時に利用する
+  # def randoku_index
+  #   all_randoku_state_books = Book.where.not(reading_state: '1') # 0 == 乱読, 2 == 通読
+  #   all_seidoku_state_books = Book.where(reading_state: '1') # 1 == 精読
+  #   all_books_count = Book.all.count
 
-    randoku_index_common_view_models =
-      ViewModel::BooksRandokuIndexCommon.new(
-        all_randoku_state_books: all_randoku_state_books,
-        all_seidoku_state_books: all_seidoku_state_books,
-        all_books_count: all_books_count,
-      )
-    randoku_index_rank_view_models =
-      ViewModel::BooksRandokuIndexRankMostImgs.new(all_randoku_state_books: all_randoku_state_books)
-    render json: {
-             status: :ok,
-             randoku_books: randoku_index_common_view_models,
-             randoku_rank: randoku_index_rank_view_models,
-           }
-  end
+  #   randoku_index_common_view_models =
+  #     ViewModel::BooksRandokuIndexCommon.new(
+  #       all_randoku_state_books: all_randoku_state_books,
+  #       all_seidoku_state_books: all_seidoku_state_books,
+  #       all_books_count: all_books_count,
+  #     )
+  #   randoku_index_rank_view_models =
+  #     ViewModel::BooksRandokuIndexRankMostImgs.new(all_randoku_state_books: all_randoku_state_books)
+  #   render json: {
+  #            status: :ok,
+  #            randoku_books: randoku_index_common_view_models,
+  #            randoku_rank: randoku_index_rank_view_models,
+  #          }
+  # end
 
   # ランキング：randoku_indexの乱読本の投稿順
   def randoku_rank_created_books
@@ -135,13 +136,25 @@ class BooksController < ApplicationController
         all_seidoku_state_books: all_seidoku_state_books,
         all_books_count: all_books_count,
       )
+    seidoku_index_common_view_models =
+      ViewModel::BooksSeidokuIndexCommon.new(
+        all_randoku_state_books: all_randoku_state_books,
+        all_seidoku_state_books: all_seidoku_state_books,
+        all_books_count: all_books_count,
+      )
     randoku_index_rank_view_models =
       ViewModel::BooksRandokuIndexRankCreatedBooks.new(all_randoku_state_books: all_randoku_state_books)
-    render json: {
-             status: :ok,
-             randoku_books: randoku_index_common_view_models,
-             randoku_rank: randoku_index_rank_view_models,
-           }
+    seidoku_index_rank_view_models =
+      ViewModel::BooksSeidokuIndexRankMostSeidokuMemos.new(all_seidoku_state_books: all_seidoku_state_books)
+    render(
+      'index_tabs',
+      locals: {
+        randoku_books: randoku_index_common_view_models,
+        randoku_rank: randoku_index_rank_view_models,
+        seidoku_books: seidoku_index_common_view_models,
+        seidoku_rank: seidoku_index_rank_view_models,
+      },
+    )
   end
 
   # ランキング：randoku_indexの乱読画像の投稿順
@@ -156,13 +169,26 @@ class BooksController < ApplicationController
         all_seidoku_state_books: all_seidoku_state_books,
         all_books_count: all_books_count,
       )
+    seidoku_index_common_view_models =
+      ViewModel::BooksSeidokuIndexCommon.new(
+        all_randoku_state_books: all_randoku_state_books,
+        all_seidoku_state_books: all_seidoku_state_books,
+        all_books_count: all_books_count,
+      )
+
     randoku_index_rank_view_models =
       ViewModel::BooksRandokuIndexRankCreatedImgs.new(all_randoku_state_books: all_randoku_state_books)
-    render json: {
-             status: :ok,
-             randoku_books: randoku_index_common_view_models,
-             randoku_rank: randoku_index_rank_view_models,
-           }
+    seidoku_index_rank_view_models =
+      ViewModel::BooksSeidokuIndexRankMostSeidokuMemos.new(all_seidoku_state_books: all_seidoku_state_books)
+    render(
+      'index_tabs',
+      locals: {
+        randoku_books: randoku_index_common_view_models,
+        randoku_rank: randoku_index_rank_view_models,
+        seidoku_books: seidoku_index_common_view_models,
+        seidoku_rank: seidoku_index_rank_view_models,
+      },
+    )
   end
 
   # 精読メモの多い順
@@ -172,12 +198,20 @@ class BooksController < ApplicationController
     all_seidoku_state_books = Book.where(reading_state: '1') # 1 == 精読
     all_books_count = Book.all.count
 
+    randoku_index_common_view_models =
+      ViewModel::BooksRandokuIndexCommon.new(
+        all_randoku_state_books: all_randoku_state_books,
+        all_seidoku_state_books: all_seidoku_state_books,
+        all_books_count: all_books_count,
+      )
     seidoku_index_common_view_models =
       ViewModel::BooksSeidokuIndexCommon.new(
         all_randoku_state_books: all_randoku_state_books,
         all_seidoku_state_books: all_seidoku_state_books,
         all_books_count: all_books_count,
       )
+    randoku_index_rank_view_models =
+      ViewModel::BooksRandokuIndexRankMostImgs.new(all_randoku_state_books: all_randoku_state_books)
     seidoku_index_rank_view_models =
       ViewModel::BooksSeidokuIndexRankMostSeidokuMemos.new(all_seidoku_state_books: all_seidoku_state_books)
     render(
@@ -205,8 +239,10 @@ class BooksController < ApplicationController
     seidoku_index_rank_view_models =
       ViewModel::BooksSeidokuIndexRankCreatedBooks.new(all_seidoku_state_books: all_seidoku_state_books)
     render(
-      'seidoku_index',
+      'index_tabs',
       locals: {
+        randoku_books: randoku_index_common_view_models,
+        randoku_rank: randoku_index_rank_view_models,
         seidoku_books: seidoku_index_common_view_models,
         seidoku_rank: seidoku_index_rank_view_models,
       },
@@ -220,17 +256,27 @@ class BooksController < ApplicationController
     all_seidoku_state_books = Book.where(reading_state: '1') # 1 == 精読
     all_books_count = Book.all.count
 
+    randoku_index_common_view_models =
+      ViewModel::BooksRandokuIndexCommon.new(
+        all_randoku_state_books: all_randoku_state_books,
+        all_seidoku_state_books: all_seidoku_state_books,
+        all_books_count: all_books_count,
+      )
     seidoku_index_common_view_models =
       ViewModel::BooksSeidokuIndexCommon.new(
         all_randoku_state_books: all_randoku_state_books,
         all_seidoku_state_books: all_seidoku_state_books,
         all_books_count: all_books_count,
       )
+    randoku_index_rank_view_models =
+      ViewModel::BooksRandokuIndexRankMostImgs.new(all_randoku_state_books: all_randoku_state_books)
     seidoku_index_rank_view_models =
       ViewModel::BooksSeidokuIndexRankMostRandokuImgs.new(all_seidoku_state_books: all_seidoku_state_books)
     render(
-      'seidoku_index',
+      'index_tabs',
       locals: {
+        randoku_books: randoku_index_common_view_models,
+        randoku_rank: randoku_index_rank_view_models,
         seidoku_books: seidoku_index_common_view_models,
         seidoku_rank: seidoku_index_rank_view_models,
       },

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -1,5 +1,4 @@
 import '@/entrypoints/js/upload_btn.js';
-//import '@/entrypoints/js/input_validation.js';
 import '@/entrypoints/js/book_input_validation.js';
 import '@/entrypoints/js/memo_input_validation.js';
 import '@/entrypoints/js/modal.js';
@@ -15,7 +14,9 @@ import '@/entrypoints/js/randoku_slide_download_btn.js';
 import '@/entrypoints/js/panzoom.js';
 import '@/entrypoints/js/navigation.js';
 import '@/entrypoints/js/tabbed.js';
-import '@/entrypoints/js/ranking_randoku_index.js';
+// ランキングをfetchで取得したくなった時に改良して使用する
+// import '@/entrypoints/js/ranking_randoku_index.js';
+
 // To see this message, add the following to the `<head>` section in your
 // views/layouts/application.html.erb
 //

--- a/app/javascript/entrypoints/js/ranking_randoku_index.js
+++ b/app/javascript/entrypoints/js/ranking_randoku_index.js
@@ -1,3 +1,4 @@
+// ランキングをfetchで取得したくなった時に使用する
 import { getCsrfToken } from './get_csrf_token.js';
 import { js_flash, js_flash_alert } from './flash.js';
 

--- a/app/view_models/view_model/books_seidoku_index_rank_created_books.rb
+++ b/app/view_models/view_model/books_seidoku_index_rank_created_books.rb
@@ -7,6 +7,12 @@ module ViewModel
       # 精読本の投稿順
       created_books_desc_of_seidoku_state_books =
         all_seidoku_state_books.order(created_at: :desc)
+      
+      # 現在乱読中の本の中から乱読画像が多い順のbook_id。1-3位まで
+      randoku_img_ranking = all_seidoku_state_books.joins(:randoku_imgs)
+      .group('books.id')
+      .select('books.id, COUNT(randoku_imgs.id) as count')
+      .order('COUNT(randoku_imgs.id) DESC').limit(3).pluck(:id)
 
       #TODO: ハッシュをクラスにする
       @books_index_rank =
@@ -14,7 +20,9 @@ module ViewModel
           {
             title: book.title,
             randoku_imgs_count: book.randoku_imgs.count,
-            seidoku_memos_count: book.seidoku_memos.count
+            seidoku_memos_count: book.seidoku_memos.count,
+            randoku_ranking: randoku_img_ranking.include?(book.id) ?
+            randoku_img_ranking.index(book.id)+1 : ""
           }
         end
     end

--- a/app/view_models/view_model/books_seidoku_index_rank_most_randoku_imgs.rb
+++ b/app/view_models/view_model/books_seidoku_index_rank_most_randoku_imgs.rb
@@ -11,13 +11,21 @@ module ViewModel
         .select('books.*, COUNT(randoku_imgs.id) as randoku_imgs_count')
         .order('randoku_imgs_count DESC')
 
+      # 現在精読中の本の中から乱読画像が多い順のbook_id。1-3位まで
+      randoku_img_ranking = all_seidoku_state_books.joins(:randoku_imgs)
+        .group('books.id')
+        .select('books.id, COUNT(randoku_imgs.id) as count')
+        .order('COUNT(randoku_imgs.id) DESC').limit(3).pluck(:id)
+      
       #TODO: ハッシュをクラスにする
       @books_index_rank =
         most_randoku_memos_desc_of_seidoku_state_books.map do |book|
           {
             title: book.title,
             randoku_imgs_count: book.randoku_imgs.count,
-            seidoku_memos_count: book.seidoku_memos.count
+            seidoku_memos_count: book.seidoku_memos.count,
+            randoku_ranking: randoku_img_ranking.include?(book.id) ?
+            randoku_img_ranking.index(book.id)+1 : ""
           }
         end
 

--- a/app/view_models/view_model/books_seidoku_index_rank_most_seidoku_memos.rb
+++ b/app/view_models/view_model/books_seidoku_index_rank_most_seidoku_memos.rb
@@ -6,18 +6,26 @@ module ViewModel
     def initialize(all_seidoku_state_books:)
       # 現在精読ステータス中の本の中から精読メモの数が多い順に並べる
       most_seidoku_memos_desc_of_seidoku_state_books =
-        all_seidoku_state_books.joins(:seidoku_memos)
+        all_seidoku_state_books.left_joins(:seidoku_memos)
         .group('books.id')
         .select('books.*, COUNT(seidoku_memos.id) as seidoku_memos_count')
         .order('seidoku_memos_count DESC')
 
+      # 現在精読中の本の中から乱読画像が多い順のbook_id。1-3位まで
+      randoku_img_ranking = all_seidoku_state_books.joins(:randoku_imgs)
+        .group('books.id')
+        .select('books.id, COUNT(randoku_imgs.id) as count')
+        .order('COUNT(randoku_imgs.id) DESC').limit(3).pluck(:id)
+      
       #TODO: ハッシュをクラスにする
       @books_index_rank =
         most_seidoku_memos_desc_of_seidoku_state_books.map do |book|
           {
             title: book.title,
             randoku_imgs_count: book.randoku_imgs.count,
-            seidoku_memos_count: book.seidoku_memos.count
+            seidoku_memos_count: book.seidoku_memos.count,
+            randoku_ranking: randoku_img_ranking.include?(book.id) ?
+            randoku_img_ranking.index(book.id)+1 : ""
           }
         end
 

--- a/app/views/books/index_seidoku_tabs.html.erb
+++ b/app/views/books/index_seidoku_tabs.html.erb
@@ -6,12 +6,12 @@
   <!-- randoku_indexの共通タブ -->
   <div class="tab tabbled-sort-area">
     <ul class="tab__menu tabbed-index-work-area border-none">
-      <li class="tab__menu-item tab-index-book-progress is-active" data-tab="01">乱読中の本</li>
-      <li class="tab__menu-item tab-index-book-progress" data-tab="02">精読中の本</li>
+      <li class="tab__menu-item tab-index-book-progress" data-tab="01">乱読中の本</li>
+      <li class="tab__menu-item tab-index-book-progress is-active" data-tab="02">精読中の本</li>
     </ul>
 
     <!---タブを切り替えた時に変わる---->
-    <div class="tab__panel-btn tab__panel-btn001 is-show" data-btn="01">
+    <div class="tab__panel-btn tab__panel-btn001" data-btn="01">
       <div class="index-book-ranking">
         <p>Total <%= randoku_books.all_randoku_state_count %>冊</p>
         <%#= raw File.read(Rails.root.join('public', 'sort.svg')) %>
@@ -41,7 +41,7 @@
     </div>
 
     <!---タブを切り替えた時に変わる---->
-    <div class="tab__panel-btn tab__panel-btn002" data-btn="02">
+    <div class="tab__panel-btn tab__panel-btn002 is-show" data-btn="02">
       <div class="index-book-ranking">
         <p>Total <%= seidoku_books.all_seidoku_state_count %>冊</p>
         <%#= raw File.read(Rails.root.join('public', 'sort.svg')) %>
@@ -56,7 +56,7 @@
           <div class="ranking-sort-navi navi-panel-js">
             <ul class="ranking-menus">
               <li class="ranking-menu">
-                <%= link_to('精読メモの多い順', :root, class: 'button') %>
+                <%= link_to('精読メモの多い順', '/books/seidoku_index', class: 'button') %>
               </li>
               <li class="ranking-menu">
                 <%= link_to('精読本の投稿順', '/books/seidoku_rank_created_books', class: 'button') %>
@@ -72,12 +72,12 @@
   </div>
 
   <div class="tab__panel">
-    <div class="tab__panel-box tab__panel-box001 is-show" data-panel="01">
+    <div class="tab__panel-box tab__panel-box001" data-panel="01">
       <!-- タブの下 乱読index -->
       <%= render partial: 'books/index_tabs/randoku_index_pre_lesson_common', locals: { books: randoku_books } %>
       <%= render partial: 'books/index_tabs/randoku_index_rank_common', locals: { books_rank: randoku_rank } %>
     </div>
-    <div class="tab__panel-box tab__panel-box002" data-panel="02">
+    <div class="tab__panel-box tab__panel-box002 is-show" data-panel="02">
       <!-- タブの下 精読index -->
       <%= render partial: 'books/index_tabs/seidoku_index_pre_lesson_common', locals: { books: seidoku_books } %>
       <%= render partial: 'books/index_tabs/seidoku_index_rank_common', locals: { books_rank: seidoku_rank } %>

--- a/app/views/books/index_tabs/_randoku_index_rank_common.html.erb
+++ b/app/views/books/index_tabs/_randoku_index_rank_common.html.erb
@@ -9,7 +9,7 @@
   <% end %>
 
   <% books_rank.books_index_rank.each_with_index do |book, i| %>
-    <div class="index-user-book-info book-<%= i %> book-<%= book[:id] %>">
+    <div class="index-user-book-info">
       <div class="index-user-book">
         <div class="index-user-book-cover">
           <% if book[:randoku_ranking].present? %>
@@ -19,8 +19,6 @@
         </div>
         <div class="index-user-book-title">
           <p class="index-book-title rank"><%= book[:title] %></p>
-          <p>book-<%= i %></p>
-          <p>book-<%= book[:id] %></p>
           <span class="index-book-progress rank"><%= book[:reading_state] %></span>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,8 @@ Rails
     get 'books/:id/' => 'books#show_tabs', :constraints => { id: /\d+/ }
 
     # randoku_inex_ランキング
-    get 'books/randoku_index' => 'books#randoku_index'
+    #get 'books/randoku_index' => 'books#randoku_index'
+    get 'books/randoku_index' => 'books#index_tabs'
     get 'books/randoku_rank_created_books' => 'books#randoku_rank_created_books'
     get 'books/randoku_rank_created_randoku_imgs' => 'books#randoku_rank_created_randoku_imgs'
 


### PR DESCRIPTION
乱読中の本、精読中の本のそれぞれのランキングリンクに対して、
fetchでの通信をやめてリダイレクトにした。

### 理由：
ランキングの順位を変更するためはhtmlテンプレをJs側で作る必要がある。
cssの命名やhtml構造を触る可能性がまだあるため、その度にJsのhtmlテンプレを触る必要がある。
現状では保守性が悪すぎるためにリダイレクト対応にした。