### PR TITLE
マージしない：vagrantでdockerを使ったproductionモードでの環境構築を試して成功

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -78,7 +78,6 @@ app/ID
 tags
 
 # 230226一旦git管理からはずした
-public/
 app/views/tmp
 app/controllers/test_controller.rb
 app/controllers/tmp_controller.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,4 +82,4 @@ RUN gem install bundler:2.3.21 && bundle config set --local path 'vendor/bundle'
 COPY . .
 
 # viteのインストール
-RUN bundle exec vite install
+#RUN bundle exec vite install

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,92 +1,24 @@
-# PostgreSQL. Versions 9.3 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On macOS with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem 'pg'
-#
 default: &default
   adapter: postgresql
   encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password: password
-  host: localhost
-  #host: my_read_memo_db
+  #host: localhost
+  host: my_read_memo_db
 
 development:
   <<: *default
   database: my_read_memo_development
 
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: my_read_memo
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
   database: my_read_memo_test
 
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password or a full connection URL as an environment
-# variable when you boot the app. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# If the connection URL is provided in the special DATABASE_URL environment
-# variable, Rails will automatically merge its configuration values on top of
-# the values provided in this file. Alternatively, you can specify a connection
-# URL environment variable explicitly:
-#
-#   production:
-#     url: <%= ENV['MY_APP_DATABASE_URL'] %>
-#
-# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full overview on how database connection configuration can be specified.
-#
 production:
   <<: *default
   database: my_read_memo_production
-  username: <%= ENV['MY_READ_MEMO_DATABASE_USERNAME'] %>
-  password: <%= ENV['MY_READ_MEMO_DATABASE_PASSWORD'] %>
-  host: <%= ENV['MY_READ_MEMO_DATABASE_HOST'] %>
-  port: 5432
+  username: <%= ENV['DOCKER_DB_USER'] %>
+  password: <%= ENV['DOCKER_DB_PASSWORD'] %>
+  #host: <%= ENV['MY_READ_MEMO_DATABASE_HOST'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true #ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
@@ -51,6 +51,7 @@ Rails.application.configure do
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
   config.log_level = :info
+  config.log_level = :debug #infoからdebugに上書き
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -119,4 +120,6 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
   # 自分で追加 230727
   config.hosts << 'yondeco.site'
+  config.hosts << 'localhost.yondeco.site'
+  config.hosts << '192.168.56.20'
 end

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,19 @@
 # version: '3'
 services:
+  my_read_memo_db:
+    image: postgres:13
+    # dbのユーザー名とパスワードでこれが無いとdbが起動できなかった
+    environment:
+      POSTGRES_USER: ${MY_READ_MEMO_DATABASE_USERNAME}
+      POSTGRES_PASSWORD: ${MY_READ_MEMO_DATABASE_PASSWORD}
+    # 無くても動くけど指定しておくとdocker-composeを停止してもdbの内容が永続化されるため、指定することが多いと思われる
+    # https://matsuand.github.io/docs.docker.jp.onthefly/storage/volumes/
+    # volumes:
+    #   - postgres_volume:/var/lib/postgresql/data
+    # 無くても動くが指定しておくとコンテナ停止時にサービスが再起動してくれる
+    # https://docs.docker.jp/v19.03/config/container/start-containers-automatically.html
+
+
   my_read_memo_web:
     build: .
     # tmp/pids/server.pidが残ってたら `A server is already running. ~~` のエラーでrailsを起動できないので事前に消してから、`rails sever` する
@@ -7,35 +21,31 @@ services:
       bash -c "
         rm -f tmp/pids/server.pid && 
         bundle install && 
+        npm install &&
         RAILS_ENV=production bundle exec rails assets:precompile && 
         bundle exec rails s -p 3000 -b '0.0.0.0' -e production
       "
     # 上記のdbイメージで指定したユーザー名とパスワードをrails側でも指定するため環境変数に設定。
     environment:
-      MY_READ_MEMO_DATABASE_USERNAME: ${MY_READ_MEMO_DATABASE_USERNAME}
-      MY_READ_MEMO_DATABASE_PASSWORD: ${MY_READ_MEMO_DATABASE_PASSWORD}
-      MY_READ_MEMO_DATABASE_HOST: ${MY_READ_MEMO_DATABASE_HOST}
+      DOCKER_DB_USER: ${MY_READ_MEMO_DATABASE_USERNAME}
+      DOCKER_DB_PASSWORD: ${MY_READ_MEMO_DATABASE_PASSWORD}
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      RAILS_ENV: production
+      RAILS_LOG_TO_STDOUT: 'true'
     # ホストのカレントディレクトリ(.)とイメージ内の/myappディレクトリを同期させている
-    volumes:
-      - .:/myapp
     ports:
       - '3000:3000' # rails用
       - '3036:3036' # vite-rails用
-    restart: always # コンテナが停止すると常に再起動
-    tty: true # 疑似ターミナル (pseudo-TTY) を割り当て。https://docs.docker.jp/compose/compose-file/index.html#tty
-    stdin_open: true # サービス コンテナに標準入力を割り当てて実行するよう設定(https://docs.docker.jp/compose/compose-file/index.html#stdin-open)。
 
   my_read_memo_webserver:
     image: nginx:latest
     ports:
       - 80:80
       - 443:443
-    restart: always
     volumes:
       - ./docker/nginx/conf/prod/:/etc/nginx/conf.d/
-      - /etc/letsencrypt/live/yondeco.site:/etc/letsencrypt/live/yondeco.site
-      - /etc/letsencrypt/archive/yondeco.site:/etc/letsencrypt/archive/yondeco.site
+      - /etc/letsencrypt/live/localhost.yondeco.site:/etc/letsencrypt/live/localhost.yondeco.site
+      - /etc/letsencrypt/archive/localhost.yondeco.site:/etc/letsencrypt/archive/localhost.yondeco.site
     # my_read_memo_webserver が my_read_memo_web に依存するように設定
     # Railsアプリケーションが完全に起動してからNginxが起動
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,56 +1,35 @@
-# version: '3'
 services:
   my_read_memo_db:
     image: postgres:13
     # dbのユーザー名とパスワードでこれが無いとdbが起動できなかった
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    # POSTGRES_USER: root
-    # POSTGRES_PASSWORD: password
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: password
     # 無くても動くけど指定しておくとdocker-composeを停止してもdbの内容が永続化されるため、指定することが多いと思われる
     # https://matsuand.github.io/docs.docker.jp.onthefly/storage/volumes/
     volumes:
       - postgres_volume:/var/lib/postgresql/data
     # 無くても動くが指定しておくとコンテナ停止時にサービスが再起動してくれる
     # https://docs.docker.jp/v19.03/config/container/start-containers-automatically.html
-    restart: always
 
   my_read_memo_web:
     build: .
     # tmp/pids/server.pidが残ってたら `A server is already running. ~~` のエラーでrailsを起動できないので事前に消してから、`rails sever` する
-    command: bash -c "rm -f tmp/pids/server.pid && bundle install && bundle exec rails s -p 3000 -b '0.0.0.0' && bin/vite dev"
+    command: bash -c "rm -f tmp/pids/server.pid && bundle install && npm install && bundle exec rails s -p 3000 -b '0.0.0.0' && bin/vite dev"
     # 上記のdbイメージで指定したユーザー名とパスワードをrails側でも指定するため環境変数に設定。
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: root 
+      POSTGRES_PASSWORD: password 
     # ホストのカレントディレクトリ(.)とイメージ内の/myappディレクトリを同期させている
     volumes:
       - .:/myapp
     ports:
       - '3000:3000' # rails用
       - '3036:3036' # vite-rails用
-    restart: always # コンテナが停止すると常に再起動
     tty: true # 疑似ターミナル (pseudo-TTY) を割り当て。https://docs.docker.jp/compose/compose-file/index.html#tty
     stdin_open: true # サービス コンテナに標準入力を割り当てて実行するよう設定(https://docs.docker.jp/compose/compose-file/index.html#stdin-open)。
     depends_on:
       - my_read_memo_db
-
-  my_read_memo_webserver:
-    image: nginx:latest
-    ports:
-      - 80:80
-      - 443:443
-    restart: always
-    volumes:
-      - ./docker/nginx/conf/dev/:/etc/nginx/conf.d/
-      - /etc/letsencrypt/live/localhost.yondeco.site:/etc/letsencrypt/live/localhost.yondeco.site
-      - /etc/letsencrypt/archive/localhost.yondeco.site:/etc/letsencrypt/archive/localhost.yondeco.site
-
-    # my_read_memo_webserver が my_read_memo_web に依存するように設定
-    # Railsアプリケーションが完全に起動してからNginxが起動
-    depends_on:
-      - my_read_memo_web
 
 volumes:
   postgres_volume:

--- a/docker/nginx/conf/prod/prod_default.conf
+++ b/docker/nginx/conf/prod/prod_default.conf
@@ -4,9 +4,9 @@ server {
 	listen 80;
 	listen 443 ssl;
 
-	server_name yondeco.site;
-	ssl_certificate /etc/letsencrypt/live/yondeco.site/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/yondeco.site/privkey.pem;
+	server_name localhost.yondeco.site;
+	ssl_certificate /etc/letsencrypt/live/localhost.yondeco.site/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/localhost.yondeco.site/privkey.pem;
 
   root /myapp/public;
 
@@ -34,12 +34,12 @@ server {
 }
 
 server {
-    if ($host = yondeco.site) {
+    if ($host = localhost.yondeco.site) {
         return 301 https://$host$request_uri;
     }
 
     listen 80;
 
-    server_name yondeco.site;
+    server_name localhost.yondeco.site;
     return 404;
 }


### PR DESCRIPTION
## （注）マージはしないこと

## 課題
- EC2 で docker を使った production モードでの環境構築がうまくいかなかった
  - [エラーの内容とやったことを表にした](https://docs.google.com/spreadsheets/d/1L4cyCPMtP5zqAKgBIkWMG1i3IxblBM_sUNf7pQk2N8M/edit#gid=0)

## 改善策
- そのため同じ要件（RDS）を使わないで vagrant でもやってみた。
- EC2 や vagrant でも docker を使った環境構築がうまくいっている開発環境用の docker-compose を改良して
本番用docker-compose.prod.ymlを作るために差分の表を作成
[dockerでのwebの本番の設定と開発の設定の差分](https://docs.google.com/spreadsheets/d/1L4cyCPMtP5zqAKgBIkWMG1i3IxblBM_sUNf7pQk2N8M/edit#gid=2020722361)

## 中間目標通過！
### vagrant では production モードの環境構築の docker 化がうまくいった！🎉

## エラーの原因
- production環境でのdockerの環境構築の失敗はvolumeの消し忘れだった。
  - これを機会にマウントする設定を削除

## 今後の予定：vagrantではうまくいったのでEC2で以下をやってみる
- [x] EC2でnginxを切った状態で同じことをやってみる
- [x] nginxを取り入れた状態&https化の状態で同じことをやってみる
- [x] dbイメージをRDSに置き換えて同じことをやってみる