### PR TITLE
ユーザーアカウントの設定ページを作成

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,2 @@
+class UsersController < ApplicationController
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,14 @@
 class UsersController < ApplicationController
+  include Secured
+
+  def account_setting
+    user_info = session[:userinfo]
+    return redirect_to root_path, alert: 'ユーザーが存在しないか、セッションが無効です。' unless user_info
+
+    user = User.find_or_initialize_by(auth0_id: user_info['sub'])
+    user_email = session[:userinfo][:email]
+
+    account_setting_view_models = ViewModel::AccountSetting.new(user: user, user_email: user_email)
+    render('account_setting', locals: { user: account_setting_view_models })
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,8 +6,7 @@ class UsersController < ApplicationController
     return redirect_to root_path, alert: 'ユーザーが存在しないか、セッションが無効です。' unless user_info
 
     user = User.find_or_initialize_by(auth0_id: user_info['sub'])
-    user_email = session[:userinfo][:email]
-
+    user_email = user_info['name']
     account_setting_view_models = ViewModel::AccountSetting.new(user: user, user_email: user_email)
     render('account_setting', locals: { user: account_setting_view_models })
   end

--- a/app/javascript/entrypoints/application.css
+++ b/app/javascript/entrypoints/application.css
@@ -12,3 +12,4 @@
 @import './styles/memo_new.css';
 @import './styles/slide.css';
 @import './styles/memo_search__result.css';
+@import './styles/account_setting.css';

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -20,6 +20,7 @@ import '@/entrypoints/js/navigation.js';
 import '@/entrypoints/js/tabbed_show.js';
 import '@/entrypoints/js/tabbed_index.js';
 import '@/entrypoints/js/sp_side_menu.js';
+import '@/entrypoints/js/account_edit_input_validation.js';
 
 // ランキングをfetchで取得したくなった時に改良して使用する
 // import '@/entrypoints/js/ranking_randoku_index.js';

--- a/app/javascript/entrypoints/js/account_edit_input_validation.js
+++ b/app/javascript/entrypoints/js/account_edit_input_validation.js
@@ -1,0 +1,71 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const accountSettingSubmit = document.querySelector('.account-setting-submit-js');
+  const inputNickname = document.querySelector('#input_nickname');
+  const nicknameValidError = document.querySelector('#nickname_valid_error');
+  const inputEmail = document.querySelector('#input_email');
+  const emailValidError = document.querySelector('#email_valid_error');
+
+  // 初期値を取得
+  const initialNicknameValue = inputNickname?.value || '';
+  const initialEmailValue = inputEmail?.value || '';
+
+  // 編集ページかどうかを確認
+  const isAccountSettingPage = document.querySelector('.account-setting') ? true : false;
+
+  // 初期状態で編集ページならボタンを無効化
+  if (accountSettingSubmit) {
+    if (isAccountSettingPage) {
+      accountSettingSubmit.disabled = true;
+    } else {
+      accountSettingSubmit.disabled = false;
+    }
+  }
+
+  if (accountSettingSubmit && inputNickname && nicknameValidError && inputEmail && emailValidError) {
+    const checkValidation = () => {
+      if (isInputNicknameValid(inputNickname) && isInputEmailValid(inputEmail)) {
+        accountSettingSubmit.disabled = false;
+      } else {
+        accountSettingSubmit.disabled = true;
+      }
+    };
+
+    const isInputNicknameValid = (inputNickname, minLength = 0, maxLength = 13) => {
+      return inputNickname.value.length >= minLength && inputNickname.value.length <= maxLength;
+    };
+
+    const isInputEmailValid = (inputEmail) => {
+      const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      return re.test(String(inputEmail.value).toLowerCase());
+    };
+
+    [inputNickname, inputEmail].forEach((input) => {
+      input.addEventListener('input', () => {
+        // ニックネームのバリデーション
+        if (input === inputNickname) {
+          nicknameValidError.textContent = isInputNicknameValid(inputNickname)
+            ? ''
+            : 'ニックネームは13文字以内で入力してください';
+        }
+
+        // emailのバリデーション
+        if (input === inputEmail) {
+          emailValidError.textContent = isInputEmailValid(inputEmail)
+            ? ''
+            : '無効なEメールアドレスです。正しい形式で入力してください';
+        }
+
+        // 入力が変更されたかどうか
+        const isValueChanged = initialNicknameValue !== inputNickname.value || initialEmailValue !== inputEmail.value;
+
+        // アカウントセッティングページで入力が変わっている場合、ボタンを有効化
+        if (isAccountSettingPage && isValueChanged) {
+          accountSettingSubmit.disabled = false;
+        }
+
+        // 全てのバリデーションをチェック
+        checkValidation();
+      });
+    });
+  }
+});

--- a/app/javascript/entrypoints/styles/account_setting.css
+++ b/app/javascript/entrypoints/styles/account_setting.css
@@ -1,0 +1,15 @@
+.user-profile-img-setting {
+  width: fit-content;
+  margin: 0px auto;
+  position: relative;
+}
+
+.user-profile-img.edit {
+  border: 0px;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background-size: cover;
+  background-position: center center;
+  box-shadow: rgba(0, 0, 0, 0.04) 0px 2px 10px;
+}

--- a/app/javascript/entrypoints/styles/account_setting.css
+++ b/app/javascript/entrypoints/styles/account_setting.css
@@ -4,7 +4,7 @@
   position: relative;
 }
 
-.user-profile-img.edit {
+.user-profile-img.account-setting {
   border: 0px;
   width: 120px;
   height: 120px;
@@ -12,4 +12,9 @@
   background-size: cover;
   background-position: center center;
   box-shadow: rgba(0, 0, 0, 0.04) 0px 2px 10px;
+}
+
+.submit-button.account-setting-submit-js {
+  margin: auto;
+  width: 70%;
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
   has_many :books
   validates :auth0_id, uniqueness: true
+  validates :nickname, length: { maximum: 13, message: '13文字以内で入力してください' }
 end

--- a/app/view_models/view_model/account_setting.rb
+++ b/app/view_models/view_model/account_setting.rb
@@ -6,7 +6,7 @@ module ViewModel
     def initialize(user:, user_email:)
       @nickname = user.nickname
       @email = user_email
-      @errors = book.errors
+      @errors = user.errors
     end
   end
 end

--- a/app/view_models/view_model/account_setting.rb
+++ b/app/view_models/view_model/account_setting.rb
@@ -1,0 +1,12 @@
+module ViewModel
+
+  class AccountSetting
+    attr_reader :nickname, :email
+
+    def initialize(user:, user_email:)
+      @nickname = user.nickname
+      @email = user_email
+      @errors = book.errors
+    end
+  end
+end

--- a/app/view_models/view_model/account_setting.rb
+++ b/app/view_models/view_model/account_setting.rb
@@ -6,7 +6,6 @@ module ViewModel
     def initialize(user:, user_email:)
       @nickname = user.nickname
       @email = user_email
-      @errors = user.errors
     end
   end
 end

--- a/app/views/users/account_setting.html.erb
+++ b/app/views/users/account_setting.html.erb
@@ -17,7 +17,7 @@
       <h1 class="font-large">プロフィール</h1>
 
       <div class="book-cover-img user-profile-img-setting">
-        <img src="/default_user_image.jpg" alt="ユーザーアイコン" class="user-profile-img edit" />
+        <img src="/default_user_image.jpg" alt="ユーザーアイコン" class="user-profile-img account-setting" />
       </div>
 
       <%= form_tag("/users/account_update", method: :put) do %>
@@ -26,7 +26,7 @@
             <p class="input-book-label font-small-12">ニックネーム</p>
             <input
               id="input_nickname"
-              class="form-oneline edit"
+              class="form-oneline account-setting"
               type="text"
               name="nickname"
               placeholder="ヴァージニア・ウルフ"
@@ -38,18 +38,18 @@
           <div class="input-book-info">
             <p class="input-book-label font-small-12">メールアドレス</p>
             <input
-              id="input_author"
-              class="form-oneline edit"
+              id="input_email"
+              class="form-oneline account-setting"
               type="text"
               name="email"
-              placeholder="e-mail"
+              placeholder="urufu@gmail.com"
               value="<%= user.email %>"
             />
             <p id="email_valid_error" class="valid_error"></p>
           </div>
         </div>
 
-        <input class="submit-button book-info-submit-js" type="submit" value="更新" disabled />
+        <input class="submit-button account-setting-submit-js" type="submit" value="更新" disabled />
       <% end %>
     </div>
   </div>

--- a/app/views/users/account_setting.html.erb
+++ b/app/views/users/account_setting.html.erb
@@ -1,0 +1,57 @@
+<main>
+  <%= render partial: 'layouts/header', locals: { user: user } %>
+
+  <!-- フラッシュを表示 -->
+  <div class="c-flash c-flash--notice slide">
+    <div class="c-flash-icon">
+      <div class="c-flash-text"></div>
+    </div>
+  </div>
+  <!-- フラッシュアラートを表示 -->
+  <div class="c-flash c-flash--alert">
+    <div class="c-flash-text"></div>
+    <i class="fa-solid fa-xmark c-flash-close" id="close-flash"></i>
+  </div>
+  <div class="main-content-js">
+    <div class="inner book-profile">
+      <h1 class="font-large">プロフィール</h1>
+
+      <div class="book-cover-img user-profile-img-setting">
+        <img src="/default_user_image.jpg" alt="ユーザーアイコン" class="user-profile-img edit" />
+      </div>
+
+      <%= form_tag("/users/account_update", method: :put) do %>
+        <div class="book-profile-form">
+          <div class="input-book-info">
+            <p class="input-book-label font-small-12">ニックネーム</p>
+            <input
+              id="input_nickname"
+              class="form-oneline edit"
+              type="text"
+              name="nickname"
+              placeholder="ヴァージニア・ウルフ"
+              value="<%= user.nickname %>"
+            />
+            <p id="nickname_valid_error" class="valid_error"></p>
+          </div>
+
+          <div class="input-book-info">
+            <p class="input-book-label font-small-12">メールアドレス</p>
+            <input
+              id="input_author"
+              class="form-oneline edit"
+              type="text"
+              name="email"
+              placeholder="e-mail"
+              value="<%= user.email %>"
+            />
+            <p id="email_valid_error" class="valid_error"></p>
+          </div>
+        </div>
+
+        <input class="submit-button book-info-submit-js" type="submit" value="更新" disabled />
+      <% end %>
+    </div>
+  </div>
+</main>
+<div class="common-footer">copywrite</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails
   .application
   .routes
   .draw do
+    get 'users/account_setting' => 'users#account_setting'
+    post 'users/account_update' => 'users#account_update'
+
     get 'books/new' => 'books#new' # new_book_page_path
     post 'books/create' => 'books#create' # book_pages_path
     get 'books/:id/' => 'books#show_tabs', :constraints => { id: /\d+/ }


### PR DESCRIPTION
## 概要
- ニックネーム、emailの設定（編集）ページを作成
- ニックネームと email は、auth0 での新規登録時に取得している
- inputバリューに表示するニックネームはdbから表示、emailはセッションデータから表示
- ユーザーの情報をあまり持ちたくないため、ニックネームはdbに保存しているが、emailはdbに保存しないようにしている

## やらないこと
updateのアクションの設定
- ニックネームはデータベースを更新
- emailはauth0側を更新
