### PR TITLE
アカウント設定ページでユーザーによるemailの更新があればauth0側のemailを更新

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,4 +10,38 @@ class UsersController < ApplicationController
     account_setting_view_models = ViewModel::AccountSetting.new(user: user, user_email: user_email)
     render('account_setting', locals: { user: account_setting_view_models })
   end
+
+  def account_update
+    user_info = session[:userinfo]
+    return redirect_to root_path, alert: 'ユーザーが存在しないか、セッションが無効です。' unless user_info
+
+    auth0_id = user_info['sub']
+    user = User.find_or_initialize_by(auth0_id: auth0_id)
+    current_email = user_info['name']
+    new_email = account_params[:email]
+    new_nickname = account_params[:nickname]
+
+    user_email = current_email if current_email == new_email
+    if current_email != new_email
+      response = Auth0UserUpdater.update_name(new_email: new_email, auth0_id: auth0_id)
+      if response != nil
+        user_email = response
+      else
+        user_email = current_email
+        flash[:error] = 'emailが更新できませんでした'
+      end
+    end
+
+    if user.nickname != new_nickname
+      user.nickname = new_nickname
+      user.save
+    end
+
+    account_setting_view_models = ViewModel::AccountSetting.new(user: user, user_email: user_email)
+    render('account_setting', locals: { user: account_setting_view_models })
+  end
+
+  def account_params
+    params.permit(:nickname, :email)
+  end
 end

--- a/app/modules/auth0_user_updater.rb
+++ b/app/modules/auth0_user_updater.rb
@@ -1,0 +1,43 @@
+module Auth0UserUpdater
+  require 'net/http'
+  require 'json'
+  require 'uri'
+
+  def self.update_name(new_email:, auth0_id:)
+    # 1. Access Tokenの取得
+    uri = URI("https://#{AUTH0_CONFIG['auth0_domain']}/oauth/token")
+    request = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/json')
+    request.body = {
+      grant_type: 'client_credentials',
+      client_id: AUTH0_CONFIG['auth0_client_id'],
+      client_secret: AUTH0_CONFIG['auth0_client_secret'],
+      audience: "https://#{AUTH0_CONFIG['auth0_domain']}/api/v2/",
+    }.to_json
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+    access_token = JSON.parse(response.body)['access_token']
+
+    # 2. ユーザーの更新
+    # auth0_idが | を含んでいるためencord
+    encoded_auth0_id = CGI.escape(auth0_id)
+    update_uri = URI("https://#{AUTH0_CONFIG['auth0_domain']}/api/v2/users/#{encoded_auth0_id}")
+
+    update_request =
+      Net::HTTP::Patch.new(
+        update_uri,
+        'Content-Type' => 'application/json',
+        'Authorization' => "Bearer #{access_token}",
+      )
+    update_request.body = { name: "#{new_email}" }.to_json
+
+    update_response =
+      Net::HTTP.start(update_uri.hostname, update_uri.port, use_ssl: true) { |http| http.request(update_request) }
+
+    if update_response.code == '200'
+      updated_data = JSON.parse(update_response.body)
+      updated_data['name']
+    else
+      nil
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails
   .routes
   .draw do
     get 'users/account_setting' => 'users#account_setting'
-    post 'users/account_update' => 'users#account_update'
+    put 'users/account_update' => 'users#account_update'
 
     get 'books/new' => 'books#new' # new_book_page_path
     post 'books/create' => 'books#create' # book_pages_path


### PR DESCRIPTION
## 関連するPR
- https://github.com/sandonemaki/my_read_memo/pull/139

上記PRの後に今回の実装をした。
## Auth0 Management API の設定を変更する必要あり
- ダッシュボードに行く
- Applications > APIs
- permissions タブに `update:users` があることを確認
- Machine To Machine Applications の 該当アプリの client_id の Authorized にチェックを入れる
- Permissions の update:users にチェックを言えれて Update ボタンをクリック