### PR TITLE
アプリから email の更新をできないようにした

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,22 +15,9 @@ class UsersController < ApplicationController
     user_info = session[:userinfo]
     return redirect_to root_path, alert: 'ユーザーが存在しないか、セッションが無効です。' unless user_info
 
-    auth0_id = user_info['sub']
-    user = User.find_or_initialize_by(auth0_id: auth0_id)
-    current_email = user_info['name']
-    new_email = account_params[:email]
+    user = User.find_or_initialize_by(auth0_id: user_info['sub'])
+    user_email = user_info['name']
     new_nickname = account_params[:nickname]
-
-    user_email = current_email if current_email == new_email
-    if current_email != new_email
-      response = Auth0UserUpdater.update_name(new_email: new_email, auth0_id: auth0_id)
-      if response != nil
-        user_email = response
-      else
-        user_email = current_email
-        flash[:error] = 'emailが更新できませんでした'
-      end
-    end
 
     if user.nickname != new_nickname
       user.nickname = new_nickname
@@ -42,6 +29,6 @@ class UsersController < ApplicationController
   end
 
   def account_params
-    params.permit(:nickname, :email)
+    params.permit(:nickname)
   end
 end

--- a/app/javascript/entrypoints/js/account_edit_input_validation.js
+++ b/app/javascript/entrypoints/js/account_edit_input_validation.js
@@ -2,12 +2,9 @@ document.addEventListener('DOMContentLoaded', function () {
   const accountSettingSubmit = document.querySelector('.account-setting-submit-js');
   const inputNickname = document.querySelector('#input_nickname');
   const nicknameValidError = document.querySelector('#nickname_valid_error');
-  const inputEmail = document.querySelector('#input_email');
-  const emailValidError = document.querySelector('#email_valid_error');
 
   // 初期値を取得
   const initialNicknameValue = inputNickname?.value || '';
-  const initialEmailValue = inputEmail?.value || '';
 
   // 編集ページかどうかを確認
   const isAccountSettingPage = document.querySelector('.account-setting') ? true : false;
@@ -21,9 +18,9 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 
-  if (accountSettingSubmit && inputNickname && nicknameValidError && inputEmail && emailValidError) {
+  if (accountSettingSubmit && inputNickname && nicknameValidError) {
     const checkValidation = () => {
-      if (isInputNicknameValid(inputNickname) && isInputEmailValid(inputEmail)) {
+      if (isInputNicknameValid(inputNickname)) {
         accountSettingSubmit.disabled = false;
       } else {
         accountSettingSubmit.disabled = true;
@@ -34,12 +31,7 @@ document.addEventListener('DOMContentLoaded', function () {
       return inputNickname.value.length >= minLength && inputNickname.value.length <= maxLength;
     };
 
-    const isInputEmailValid = (inputEmail) => {
-      const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-      return re.test(String(inputEmail.value).toLowerCase());
-    };
-
-    [inputNickname, inputEmail].forEach((input) => {
+    [inputNickname].forEach((input) => {
       input.addEventListener('input', () => {
         // ニックネームのバリデーション
         if (input === inputNickname) {
@@ -48,15 +40,8 @@ document.addEventListener('DOMContentLoaded', function () {
             : 'ニックネームは13文字以内で入力してください';
         }
 
-        // emailのバリデーション
-        if (input === inputEmail) {
-          emailValidError.textContent = isInputEmailValid(inputEmail)
-            ? ''
-            : '無効なEメールアドレスです。正しい形式で入力してください';
-        }
-
         // 入力が変更されたかどうか
-        const isValueChanged = initialNicknameValue !== inputNickname.value || initialEmailValue !== inputEmail.value;
+        const isValueChanged = initialNicknameValue !== inputNickname.value;
 
         // アカウントセッティングページで入力が変わっている場合、ボタンを有効化
         if (isAccountSettingPage && isValueChanged) {

--- a/app/javascript/entrypoints/styles/common.css
+++ b/app/javascript/entrypoints/styles/common.css
@@ -26,6 +26,9 @@ h1 {
 .font-small-12 {
   font-size: 12px;
 }
+.font-small-14 {
+  font-size: 14px;
+}
 .font-small-10 {
   font-size: 10px;
 }

--- a/app/views/users/account_setting.html.erb
+++ b/app/views/users/account_setting.html.erb
@@ -19,6 +19,10 @@
       <div class="book-cover-img user-profile-img-setting">
         <img src="/default_user_image.jpg" alt="ユーザーアイコン" class="user-profile-img account-setting" />
       </div>
+      <div class="book-profile-form">
+        <p class="input-book-label font-small-12">ログインしているメールアドレス</p>
+        <p class="font-small-14"><%= user.email %></p>
+      </div>
 
       <%= form_tag("/users/account_update", method: :put) do %>
         <div class="book-profile-form">
@@ -34,21 +38,7 @@
             />
             <p id="nickname_valid_error" class="valid_error"></p>
           </div>
-
-          <div class="input-book-info">
-            <p class="input-book-label font-small-12">メールアドレス</p>
-            <input
-              id="input_email"
-              class="form-oneline account-setting"
-              type="text"
-              name="email"
-              placeholder="urufu@gmail.com"
-              value="<%= user.email %>"
-            />
-            <p id="email_valid_error" class="valid_error"></p>
-          </div>
         </div>
-
         <input class="submit-button account-setting-submit-js" type="submit" value="更新" disabled />
       <% end %>
     </div>


### PR DESCRIPTION
## 概要
ログイン用のemailの更新ができると思っていたが、Auth0ではログインようのemailが更新できないことがわかった。
自分が更新していたのは、`auth_info = request.env['omniauth.auth']` の中の name
email もあるが、ログイン用の email ではないようだった。

そのため email をアプリの中からは更新できないようにした。
ログインしているメールアドレスは更新はできないが、表示するようにした

## 依存 PR
- https://github.com/sandonemaki/my_read_memo/pull/141
