### PR TITLE
auth0.ymlの設定をEC２でも使えるよう値を環境変数にした

### DIFF
--- a/config/auth0.yml
+++ b/config/auth0.yml
@@ -1,4 +1,4 @@
 development:
-  auth0_domain: dev-7qxwedclc2ny61n1.us.auth0.com
-  auth0_client_id: zDpBreWMMcMWL4aGMR5zGj4MfD1ILzjB
+  auth0_domain: <%= ENV['AUTH0_DOMAIN'] %>
+  auth0_client_id: <%= ENV['AUTH0_CLIENT_ID'] %> 
   auth0_client_secret: <%= ENV['AUTH0_CLIENT_SECRET'] %>

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,9 @@ services:
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
       RAILS_ENV: production
       RAILS_LOG_TO_STDOUT: 'true'
+      AUTH0_CLIENT_SECRET: ${AUTH0_CLIENT_SECRET}
+      AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID}
+      AUTH0_DOMAIN: ${AUTH0_DOMAIN}
 
   my_read_memo_webserver:
     image: nginx:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       AUTH0_CLIENT_SECRET: ${AUTH0_CLIENT_SECRET}
+      AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID}
+      AUTH0_DOMAIN: ${AUTH0_DOMAIN}
     volumes:
       - .:/myapp
     tty: true # 疑似ターミナル (pseudo-TTY) を割り当て。https://docs.docker.jp/compose/compose-file/index.html#tty


### PR DESCRIPTION
EC2での設定方法
- Auth0のRailsチュートリアル
  - https://auth0.com/docs/quickstart/webapp/rails/interactive